### PR TITLE
New option: retain parts of the cloze as text using a regular expression

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,22 @@ Alternatively, for `data-cloze-show-before="all"` and `data-cloze-show-after="no
 
 ![hamlet2](https://raw.githubusercontent.com/matthayes/anki_cloze_anything/master/images/hamlet2.png)
 
+#### data-cloze-keep-regex
+
+This contains a regular expression that determines what parts of the text should not be replace with blanks, as if they were surrounded with backticks.  By default it contains basic Latin-script punctuation marks, which most users would want to show in the cloze.  A more comprehensive set of punctuation marks from different scripts can be set by using:
+
+```
+data-cloze-keep-regex="[!()+,./:;?{}¡«»¿׃‒–—‘’‚“”„‥…‧‹›♪⟨⟩ ⸮、。〈〉《》「」『』【】〝〟〽﹁﹂！（），：；？［］｛｝～\[\]]"
+```
+
+Thanks to the fact that this field is a regular expression, you can use it for all kinds for special scenarios.  For example, if you want to show the text from the beginning of the clause until the first colon, in addition to basic Latin-script punctuation, but hide everything else you can use:
+
+```
+data-cloze-keep-regex="^.*?:|[!,.:;?—–]"
+```
+
+This option has an effect only if `data-cloze-replace-same-length` is set.
+
 ### Overriding Configuration
 
 If you'd like to override any default configuration values for certain cards, one way to achieve this is

--- a/docs/INSTRUCTIONS.md
+++ b/docs/INSTRUCTIONS.md
@@ -44,7 +44,8 @@ var defaults = {
   alwaysShowBlanks: "false",
   blanksFormat: "[{blanks}]",
   hintFormat: "[{hint}]",
-  blanksAndHintFormat: "[{blanks}|{hint}]"
+  blanksAndHintFormat: "[{blanks}|{hint}]",
+  keepRegex: /[!,.:;?—–]/,
 }
 
 var expEl = document.getElementById("cloze");
@@ -75,12 +76,22 @@ var hintFormat = expEl.getAttribute("data-cloze-hint-format") || defaults.hintFo
 // Format of the cloze when we are showing the blanks and a hint.
 var blanksAndHintFormat = expEl.getAttribute("data-cloze-blanks-and-hint-format") || defaults.blanksAndHintFormat;
 
+// A regular expression that determines what parts of the text should not be replace with blanks,
+// as if they were surrounded with backticks.
+var keepRegex;
+if (expEl.hasAttribute("data-cloze-keep-regex")) {
+  keepRegex = RegExp(expEl.getAttribute("data-cloze-keep-regex"));
+}
+else {
+  keepRegex = defaults.keepRegex;
+}
+
 // Identify characters in content that will not be replaced with blanks.
 var charKeepRegex = /(`.+?`)/
 var charKeepGlobalRegex = /(`.+?`)/g
 
 // Regex used to split on spaces so spaces can be preserved.
-var spaceSplit = /(\s+)/;
+var spaceSplit = /\s+/;
 
 // Matches diacritics so we can remove them for length computation purposes.
 var combiningDiacriticMarks = /[\u0300-\u036f]/g;
@@ -101,7 +112,7 @@ function replace_chars_with_blanks(content) {
   // Decompose so we can remove diacritics to compute an accurate length.  Otherwise
   // diacritics may contibute towards the length, which we don't want.
   content = content.normalize("NFD").replace(combiningDiacriticMarks, "");
-  var split = content.split(spaceSplit);
+  var split = content.split(RegExp("(" + spaceSplit.source + "|" + keepRegex.source + ")"));
   var parts = []
   split.forEach(function(p, i) {
     if (i % 2 == 0) {

--- a/docs/INSTRUCTIONS.md
+++ b/docs/INSTRUCTIONS.md
@@ -45,7 +45,7 @@ var defaults = {
   blanksFormat: "[{blanks}]",
   hintFormat: "[{hint}]",
   blanksAndHintFormat: "[{blanks}|{hint}]",
-  keepRegex: /[!,.:;?—–]/,
+  keepRegex: /[!,.:;?—–…]/,
 }
 
 var expEl = document.getElementById("cloze");

--- a/examples/cloze_anything.js
+++ b/examples/cloze_anything.js
@@ -22,7 +22,8 @@ var defaults = {
   alwaysShowBlanks: "false",
   blanksFormat: "[{blanks}]",
   hintFormat: "[{hint}]",
-  blanksAndHintFormat: "[{blanks}|{hint}]"
+  blanksAndHintFormat: "[{blanks}|{hint}]",
+  keepRegex: /[!,.:;?—–]/,
 }
 
 var expEl = document.getElementById("cloze");
@@ -53,12 +54,22 @@ var hintFormat = expEl.getAttribute("data-cloze-hint-format") || defaults.hintFo
 // Format of the cloze when we are showing the blanks and a hint.
 var blanksAndHintFormat = expEl.getAttribute("data-cloze-blanks-and-hint-format") || defaults.blanksAndHintFormat;
 
+// A regular expression that determines what parts of the text should not be replace with blanks,
+// as if they were surrounded with backticks.
+var keepRegex;
+if (expEl.hasAttribute("data-cloze-keep-regex")) {
+  keepRegex = RegExp(expEl.getAttribute("data-cloze-keep-regex"));
+}
+else {
+  keepRegex = defaults.keepRegex;
+}
+
 // Identify characters in content that will not be replaced with blanks.
 var charKeepRegex = /(`.+?`)/
 var charKeepGlobalRegex = /(`.+?`)/g
 
 // Regex used to split on spaces so spaces can be preserved.
-var spaceSplit = /(\s+)/;
+var spaceSplit = /\s+/;
 
 // Matches diacritics so we can remove them for length computation purposes.
 var combiningDiacriticMarks = /[\u0300-\u036f]/g;
@@ -79,7 +90,7 @@ function replace_chars_with_blanks(content) {
   // Decompose so we can remove diacritics to compute an accurate length.  Otherwise
   // diacritics may contibute towards the length, which we don't want.
   content = content.normalize("NFD").replace(combiningDiacriticMarks, "");
-  var split = content.split(spaceSplit);
+  var split = content.split(RegExp("(" + spaceSplit.source + "|" + keepRegex.source + ")"));
   var parts = []
   split.forEach(function(p, i) {
     if (i % 2 == 0) {

--- a/examples/cloze_anything.js
+++ b/examples/cloze_anything.js
@@ -23,7 +23,7 @@ var defaults = {
   blanksFormat: "[{blanks}]",
   hintFormat: "[{hint}]",
   blanksAndHintFormat: "[{blanks}|{hint}]",
-  keepRegex: /[!,.:;?—–]/,
+  keepRegex: /[!,.:;?—–…]/,
 }
 
 var expEl = document.getElementById("cloze");

--- a/examples/front.html
+++ b/examples/front.html
@@ -43,7 +43,7 @@ var defaults = {
   blanksFormat: "[{blanks}]",
   hintFormat: "[{hint}]",
   blanksAndHintFormat: "[{blanks}|{hint}]",
-  keepRegex: /[!,.:;?—–]/,
+  keepRegex: /[!,.:;?—–…]/,
 }
 
 var expEl = document.getElementById("cloze");

--- a/examples/front.html
+++ b/examples/front.html
@@ -42,7 +42,8 @@ var defaults = {
   alwaysShowBlanks: "false",
   blanksFormat: "[{blanks}]",
   hintFormat: "[{hint}]",
-  blanksAndHintFormat: "[{blanks}|{hint}]"
+  blanksAndHintFormat: "[{blanks}|{hint}]",
+  keepRegex: /[!,.:;?—–]/,
 }
 
 var expEl = document.getElementById("cloze");
@@ -73,12 +74,22 @@ var hintFormat = expEl.getAttribute("data-cloze-hint-format") || defaults.hintFo
 // Format of the cloze when we are showing the blanks and a hint.
 var blanksAndHintFormat = expEl.getAttribute("data-cloze-blanks-and-hint-format") || defaults.blanksAndHintFormat;
 
+// A regular expression that determines what parts of the text should not be replace with blanks,
+// as if they were surrounded with backticks.
+var keepRegex;
+if (expEl.hasAttribute("data-cloze-keep-regex")) {
+  keepRegex = RegExp(expEl.getAttribute("data-cloze-keep-regex"));
+}
+else {
+  keepRegex = defaults.keepRegex;
+}
+
 // Identify characters in content that will not be replaced with blanks.
 var charKeepRegex = /(`.+?`)/
 var charKeepGlobalRegex = /(`.+?`)/g
 
 // Regex used to split on spaces so spaces can be preserved.
-var spaceSplit = /(\s+)/;
+var spaceSplit = /\s+/;
 
 // Matches diacritics so we can remove them for length computation purposes.
 var combiningDiacriticMarks = /[\u0300-\u036f]/g;
@@ -99,7 +110,7 @@ function replace_chars_with_blanks(content) {
   // Decompose so we can remove diacritics to compute an accurate length.  Otherwise
   // diacritics may contibute towards the length, which we don't want.
   content = content.normalize("NFD").replace(combiningDiacriticMarks, "");
-  var split = content.split(spaceSplit);
+  var split = content.split(RegExp("(" + spaceSplit.source + "|" + keepRegex.source + ")"));
   var parts = []
   split.forEach(function(p, i) {
     if (i % 2 == 0) {


### PR DESCRIPTION
First of all, I want to thank you for Anki Cloze Anything. I use it daily in my Anki reviews, and it made a tremendous impact on my use of Anki for improving my language production ability in Norwegian and Welsh (as opposed to reading and listening comprehension, which do not benefit from cloze deletion). 🌼

One thing I found lacking is Anki Cloze Anything’s inability to distinguish punctuation and non-punctuation characters (with `data-cloze-replace-same-length` set), leading to `((c1::Hello, my name is Inigo Montoya.))` appearing in the cloze as `______ __ ____ __ _____ ________` (6, 2, 4, 2, 5, 8 characters), instead of the more reasonable `_____, __ ____ __ _____ _______.` (5, 2, 4, 2, 5, 7 characters).

This pull request aims at fixing this, allowing users to determine what what parts of the text should not be replace with blanks. I tried to write it in the same manner and style of the project (I even used [two spaces](https://practicaltypography.com/are-two-spaces-better-than-one.html) in `README.md`… 🙂). I hope you find this well-written and helpful, and merge it to the main repository.